### PR TITLE
empty chartTitle is now possible to save

### DIFF
--- a/lib/builder/components/ChartContainer.js
+++ b/lib/builder/components/ChartContainer.js
@@ -175,12 +175,13 @@ class ChartContainer extends Component {
     } = this.props;
     const { loading, results, type } = this.state;
     let containerTitle = chartTitle;
-    if (!containerTitle && results && results.metadata && results.metadata.display_name) {
+    const shouldDisplayName = (containerTitle === undefined) && results && results.metadata && results.metadata.display_name;
+    if (shouldDisplayName) {
       containerTitle = results.metadata.display_name;
     }
     return (
       <React.Fragment>
-        {(version === "editor" || (version === "viewer" && chartTitle)) && (
+        {(version === "editor" || (version === "viewer" && containerTitle)) && (
           <div className="chart-title">
             <input
               type="text"

--- a/lib/builder/components/EditorToolbar.js
+++ b/lib/builder/components/EditorToolbar.js
@@ -25,10 +25,8 @@ class EditorToolbar extends Component {
     const left = 350;
     const width = 500;
     const height = 300;
-    const chartTitle = "";
     const newElement = {
       type: name,
-      chartTitle,
       top,
       left,
       width,

--- a/lib/func/oldDashboardDataParse.js
+++ b/lib/func/oldDashboardDataParse.js
@@ -43,7 +43,6 @@ export default function editorParse(oldDashboard) {
               : ((1200 - 40 - (r.tiles.length - 1) * grid) / 12) *
                 t.column_width;
           return {
-            chartTitle: "",
             height: Math.round(r.height / grid) * grid,
             width: Math.round(elWidth / grid) * grid,
             top: topPosition - r.height + i * grid,

--- a/lib/viewer/components/EditorDashboard.js
+++ b/lib/viewer/components/EditorDashboard.js
@@ -32,10 +32,8 @@ class EditorDashboard extends Component {
       grid;
     const width = 500;
     const height = 300;
-    const chartTitle = "";
     const newElement = {
       type: draggedType,
-      chartTitle,
       ...checkBoundaries(
         top,
         left,


### PR DESCRIPTION
- chartTitle is undefined unless user chooses a saved query
- then we use savedQuery name as a chartTitle
- user can delete this name and save empty string