### PR TITLE
fix: 🐛 filter saved queries with display_name in metadata

### DIFF
--- a/lib/builder/components/SavedQueriesSelect.js
+++ b/lib/builder/components/SavedQueriesSelect.js
@@ -20,7 +20,9 @@ class SavedQueriesSelect extends Component {
           if (
             ChartTypeUtils.getChartTypeOptions(el.query).includes(
               this.props.type
-            )
+            ) &&
+            el.metadata &&
+            el.metadata.display_name
           ) {
             return el;
           }
@@ -43,7 +45,9 @@ class SavedQueriesSelect extends Component {
             if (
               ChartTypeUtils.getChartTypeOptions(el.query).includes(
                 nextProps.type
-              )
+              ) &&
+              el.metadata &&
+              el.metadata.display_name
             ) {
               return el;
             }


### PR DESCRIPTION
older queries don't have any metadata

https://github.com/keen/keen/issues/36