### PR TITLE
fix: 🐛 chart tooltips in ff

### DIFF
--- a/lib/viewer/components/EditorDashboard.js
+++ b/lib/viewer/components/EditorDashboard.js
@@ -212,6 +212,7 @@ class EditorDashboard extends PureComponent {
           isDroppable={version === 'editor'}
           droppingItem={{ i: 'shadow', w: 2, h: 4 }}
           rowHeight={30}
+          useCSSTransforms={false}
         >
           {items && items.map(item => this.createElement(item))}
         </ResponsiveReactGridLayout>


### PR DESCRIPTION
https://metakeen.atlassian.net/browse/FEE-436

```
// Uses CSS3 translate() instead of position top/left.
// This makes about 6x faster paint performance
useCSSTransforms: ?boolean = true,
```

https://github.com/STRML/react-grid-layout